### PR TITLE
Update Dashboard Background and Disable Dark Mode

### DIFF
--- a/app/dashboard/page.jsx
+++ b/app/dashboard/page.jsx
@@ -5,7 +5,7 @@ import FormList from './_components/FormList'
 
 function Dashboard() {
     return (
-        <div className='p-10'>
+        <div className='p-10 min-h-screen'>
             <h2 className='font-bold text-3xl flex items-center justify-between'>Dashboard
                 <CreateForm />
             </h2>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: ["class"],
+  // darkMode: ["class"],
   content: [
     './pages/**/*.{js,jsx}',
     './components/**/*.{js,jsx}',


### PR DESCRIPTION
### Pull Request: Disable Dark Mode and Add `min-h-screen` to Dashboard Component

#### Description of Changes
- **Disabled Dark Mode:** Removed the `darkMode` key from the Tailwind CSS configuration to completely disable dark mode styling.
- **Added `min-h-screen` to Dashboard Component:** Ensures that the dashboard background color covers the entire page, extending to the bottom.

#### Code Changes

**Tailwind CSS Configuration:**
```javascript
// Removed or commented out the darkMode key to disable dark mode
module.exports = {
  // darkMode: ["class"],
  content: [
    './pages/**/*.{js,jsx}',
    './components/**/*.{js,jsx}',
    './app/**/*.{js,jsx}',
    './src/**/*.{js,jsx}',
  ],
  // ...rest of the configuration
};
```

**Dashboard Component:**
```javascript
import React from 'react';
import CreateForm from './_components/CreateForm';
import FormList from './_components/FormList';

function Dashboard() {
    return (
        <div className='p-10 min-h-screen'>
            <h2 className='font-bold text-3xl flex items-center justify-between'>
                Dashboard
                <CreateForm />
            </h2>
            <FormList />
        </div>
    );
}

export default Dashboard;
```

#### Testing Steps
1. **Local Development:**
   - Verified that dark mode styles are no longer applied throughout the application by running it locally and inspecting various pages.
   
2. **Dashboard Layout:**
   - Ensured that the `min-h-screen` class applied to the dashboard component effectively extends the background color to the bottom of the page, even when there is minimal content.

3. **UI Verification:**
   - Checked the overall UI to confirm that removing dark mode does not affect other styling and functionality.
   - Verified the appearance and functionality of the `CreateForm` and `FormList` components within the Dashboard.